### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 A Model Context Protocol (MCP) server that brings the power of AI to your Xcode projects. This server acts as a bridge between Claude and your local Xcode development environment, enabling intelligent code assistance, project management, and automated development tasks.
 
+<a href="https://glama.ai/mcp/servers/mmxuwmm7sc"><img width="380" height="200" src="https://glama.ai/mcp/servers/mmxuwmm7sc/badge" alt="Xcode Server MCP server" /></a>
+
 ## What is Xcode MCP Server?
 
 At its core, this server follows a client-server architecture where Claude can securely interact with your local Xcode projects:


### PR DESCRIPTION
This PR adds a badge for the [Xcode MCP Server](https://glama.ai/mcp/servers/mmxuwmm7sc) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/mmxuwmm7sc"><img width="380" height="200" src="https://glama.ai/mcp/servers/mmxuwmm7sc/badge" alt="Xcode Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.