### PR TITLE
Add execAsync security audit documentation

### DIFF
--- a/docs/exec-safety-audit.md
+++ b/docs/exec-safety-audit.md
@@ -1,0 +1,16 @@
+# execAsync Injection Review
+
+This document summarizes each usage of `execAsync` within `src/tools` and whether
+user supplied input is passed to the shell. When a potential injection vector is
+found, a mitigation strategy is noted.
+
+| File & Line | Parameters | Status |
+|-------------|-----------|--------|
+| `project/index.ts` lines around 337 | `cleanedPath` from user path | Switched to `execFile` to avoid shell injection |
+| `simulator/index.ts` boot/install/etc | `udid`, `bundleId`, `url` parameters | Potential injection; consider validating against `[0-9A-F-]+` and using `execFile` |
+| `file/index.ts` copy/info operations | validated file paths | Quoting with `"` may allow injection if path contains quotes. Use `execFile` or sanitize path. |
+| `build/index.ts` build/clean/archive commands | `scheme`, `configuration`, paths | Strings passed directly to shell; sanitize or use `execFile`. |
+| `spm/index.ts` package commands | package names, options | Strings interpolated; validate or use `execFile`. |
+| `cocoapods/index.ts` | boolean flags only | Low risk. |
+| `xcode/index.ts` various commands | parameters like `command`, `developerDir` | Validate or use `execFile`. |
+

--- a/docs/tools-overview.md
+++ b/docs/tools-overview.md
@@ -122,4 +122,5 @@ Simulator tools allow you to interact with iOS simulators. They use the `simctl`
 | Tool | Description |
 |------|-------------|
 | `run_xcrun` | Executes a specified Xcode tool via 'xcrun' |
-| `
+
+See docs/exec-safety-audit.md for a review of shell command usage.

--- a/src/tools/project/index.ts
+++ b/src/tools/project/index.ts
@@ -3,7 +3,7 @@ import * as fs from "fs/promises";
 import * as fsSync from "fs";
 import * as path from "path";
 import { promisify } from "util";
-import { exec } from "child_process";
+import { exec, execFile } from "child_process";
 import { XcodeServer } from "../../server.js";
 import { getProjectInfo } from "../../utils/project.js";
 import { ProjectNotFoundError, PathAccessError, FileOperationError, CommandExecutionError } from "../../utils/errors.js";
@@ -335,17 +335,15 @@ export function registerProjectTools(server: XcodeServer) {
           try {
             // Use AppleScript to tell Xcode to open the project
             const { promisify } = await import('util');
-            const { exec } = await import('child_process');
-            const execAsyncFn = promisify(exec);
+            const { execFile } = await import('child_process');
+            const execFileAsync = promisify(execFile);
 
-            await execAsyncFn(`
-              osascript -e '
-                tell application "Xcode"
-                  open "${cleanedPath}"
-                  activate
-                end tell
-              '
-            `);
+            await execFileAsync('osascript', [
+              '-e',
+              `tell application "Xcode" to open POSIX file "${cleanedPath}"`,
+              '-e',
+              'activate'
+            ]);
             xcodeOpenStatus = " and opened in Xcode";
           } catch (openError) {
             console.error("Failed to open project in Xcode:", openError);


### PR DESCRIPTION
## Summary
- document possible command injection vectors using execAsync
- mention safety audit in tools overview
- replace shell invocation with execFile in project tool

## Testing
- `npm run build` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_6841da2aef4c832e835ee0534008a9f9